### PR TITLE
Apparently 'Git tag' is no longer a valid tag source

### DIFF
--- a/AzurePipelines/PublishMaster.yml
+++ b/AzurePipelines/PublishMaster.yml
@@ -40,6 +40,6 @@ steps:
     repositoryName: 'DumpsterDoofus/Twitch-Chat-Downloader'
     action: 'create'
     target: '$(Build.SourceVersion)'
-    tagSource: 'Git tag'
+    tagSource: 'auto'
     tag: '$(releaseVersion)'
     assets: '$(Build.ArtifactStagingDirectory)\TwitchChatDownloader\*'


### PR DESCRIPTION
## Description of Change

- [ ] Did you update the release version? See [here](https://github.com/DumpsterDoofus/Twitch-Chat-Downloader/blob/master/AzurePipelines/PublishMaster.yml#L2) and [here](https://github.com/DumpsterDoofus/Twitch-Chat-Downloader/blob/master/TwitchChatDownloader/TwitchChatDownloader.csproj#L7). **Not needed**